### PR TITLE
feat: restrict file input types

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <div class="container">
       <div class="input">
         <label for="file-input">Select image file:</label>
-        <input type="file" id="file-input" placeholder="BConverter">
+        <input type="file" id="file-input" placeholder="BConverter" accept="image/jpeg,image/png">
 
       </div>
       <div class="buttons">


### PR DESCRIPTION
## Summary
- limit image chooser to JPEG or PNG files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68935d9da8dc8324861049f14f6285c4