### PR TITLE
Add Jest setup and showMessage unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/js/app.js
+++ b/js/app.js
@@ -119,3 +119,7 @@ navbarToggle.addEventListener('click', () => {
   navbarToggle.classList.toggle('active');
   navbarLinks.classList.toggle('active');
 });
+
+if (typeof module !== 'undefined') {
+  module.exports = { showMessage };
+}

--- a/js/app.test.js
+++ b/js/app.test.js
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const { showMessage } = require('./app');
+
+describe('showMessage', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="message-container"></div>';
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('adds and removes show class after 3 seconds', () => {
+    const message = 'testing';
+    showMessage(message);
+    const container = document.getElementById('message-container');
+    expect(container.classList.contains('show')).toBe(true);
+    expect(container.textContent).toBe(message);
+    jest.advanceTimersByTime(3000);
+    expect(container.classList.contains('show')).toBe(false);
+    expect(container.textContent).toBe('');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "imageconverter",
+  "version": "1.0.0",
+  "description": "<h1>🖼️ Image Converter</h1>",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}


### PR DESCRIPTION
## Summary
- expose `showMessage` for testing
- configure Jest with jsdom environment
- add unit test verifying `showMessage` toggles the `show` class and clears message after 3s

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68935e8c04e8832480bcaa46ebcfc5fa