### PR TITLE
Check file selection before reading

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -12,6 +12,9 @@ let convertedType = null;
 
 fileInput.addEventListener('change', () => {
   const file = fileInput.files[0];
+  if (!file) {
+    return;
+  }
   const reader = new FileReader();
 
   reader.onload = () => {


### PR DESCRIPTION
## Summary
- Avoid instantiating `FileReader` when no file is chosen

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f3c59e6483248dd49f82c65f3e7c